### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Ensure Poetry is installed
+if ! command -v poetry >/dev/null 2>&1; then
+    pip install --upgrade pip
+    pip install --user poetry
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install project dependencies without creating a virtual environment
+poetry config virtualenvs.create false
+poetry install --no-interaction --no-ansi
+


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Poetry and project dependencies for testing

## Testing
- `./setup.sh` *(fails: All attempts to connect to pypi.org failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684957a569f88332a2ad5a27c6ef0e37