### PR TITLE
Fix setup script merge leftovers

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,15 +20,4 @@ poetry config virtualenvs.create false
 
 # Install project dependencies
 poetry install --no-interaction --no-ansi
-=======
-# Ensure Poetry is installed
-if ! command -v poetry >/dev/null 2>&1; then
-    pip install --upgrade pip
-    pip install --user poetry
-    export PATH="$HOME/.local/bin:$PATH"
-fi
-
-# Install project dependencies without creating a virtual environment
-poetry config virtualenvs.create false
-poetry install --no-interaction --no-ansi
 


### PR DESCRIPTION
## Summary
- remove leftover merge markers from `setup.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `poetry install --no-interaction --no-ansi` *(fails: All attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_b_6849676207648332b9a40dd9954abd5a